### PR TITLE
feat(database): add Helm chart for the EAASI Database

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -92,10 +92,13 @@ jobs:
       - name: Start Minikube cluster
         run: just cluster-start
       - *install-helm-step
-      - *install-ct-step
       - *add-chart-repos-step
-      - name: Install and test charts
-        run: ct install --config ./configs/chart-testing.yaml --all
+      - name: Build chart dependencies
+        run: just build-chart-deps
+      - name: Install charts
+        run: just deploy-all
+      - name: Test charts
+        run: just test-all
 
   spell-checker:
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -106,3 +106,9 @@ cluster-unpause name=cluster:
 # Delete a Minikube cluster
 cluster-delete name=cluster:
   minikube delete --profile "{{ name }}"
+
+### EAASI #####################################################################
+
+# Deploy the database-operator
+deploy-database-operator name="database-operator" ns="cnpg-system" *args="--wait": \
+  (upgrade "database" name ns "-f" (chart_dir / "database/configs/operator.yaml") args)

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,10 @@ cluster := "eaasi"
 # Name of the cluster namespace
 namespace := "eaasi"
 
+# Defaults for database-cluster
+database_cluster_name := "database-cluster"
+database_cluster_ns := "database"
+
 ### HELPERS ###################################################################
 
 # Run spell checker
@@ -112,3 +116,7 @@ cluster-delete name=cluster:
 # Deploy the database-operator
 deploy-database-operator name="database-operator" ns="cnpg-system" *args="--wait": \
   (upgrade "database" name ns "-f" (chart_dir / "database/configs/operator.yaml") args)
+
+# Deploy the database-cluster
+deploy-database-cluster name=database_cluster_name ns=database_cluster_ns *args="--wait": \
+  (upgrade "database" name ns args)

--- a/Justfile
+++ b/Justfile
@@ -84,6 +84,10 @@ render chart name=chart ns=namespace *args:
   helm template "{{ name }}" "{{ chart_dir / chart }}" \
     --namespace "{{ ns }}" {{ args }} | less
 
+# Test a Helm chart release
+test release ns=namespace *args:
+  helm test "{{ release }}" --namespace "{{ ns }}" {{ args }}
+
 ### MINIKUBE ##################################################################
 
 # Start a Minikube cluster
@@ -125,3 +129,11 @@ deploy-database-cluster name=database_cluster_name ns=database_cluster_ns *args=
 deploy-all: \
   (deploy-database-operator) \
   (deploy-database-cluster) \
+
+# Test the database-cluster
+test-database-cluster name=database_cluster_name ns=database_cluster_ns *args: \
+  (test name ns args)
+
+# Test all components
+test-all: \
+  (test-database-cluster) \

--- a/Justfile
+++ b/Justfile
@@ -43,7 +43,7 @@ update-changelog chart version="" dir=(chart_dir / chart):
 
 # Add external chart repositories
 add-chart-repos:
-  # TODO: add repos!
+  helm repo add "cnpg" "https://cloudnative-pg.github.io/charts"
 
 # Build dependencies for all charts
 build-chart-deps:

--- a/Justfile
+++ b/Justfile
@@ -120,3 +120,8 @@ deploy-database-operator name="database-operator" ns="cnpg-system" *args="--wait
 # Deploy the database-cluster
 deploy-database-cluster name=database_cluster_name ns=database_cluster_ns *args="--wait": \
   (upgrade "database" name ns args)
+
+# Deploy all components
+deploy-all: \
+  (deploy-database-operator) \
+  (deploy-database-cluster) \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ $ helm search repo eaasi
 ## Charts
 
 For more details, see the documentation for each chart:
+- [database](./charts/database/README.md)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Next, rebuild all required chart dependencies with:
 $ just build-chart-deps
 ```
 
+The [database-operator](./charts/database) can be deployed with:
+
+```console
+$ just deploy-database-operator  # <name> <namespace>
+```
+
+Then, a [database-cluster](./charts/database) can be deployed with:
+
+```console
+$ just deploy-database-cluster  # <name> <namespace>
+```
+
 ## License
 
 Helm charts for EAASI are distributed under the [Apache-2.0](./LICENSE) license.

--- a/charts/database/.helmignore
+++ b/charts/database/.helmignore
@@ -1,5 +1,6 @@
 # Patterns to ignore when building packages.
 
+CHANGELOG.md
 .DS_Store
 
 # Common VCS dirs

--- a/charts/database/.helmignore
+++ b/charts/database/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+
+.DS_Store
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/database/CHANGELOG.md
+++ b/charts/database/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## database-0.5.0 - *2025-03-21*
+
+### Features
+
+- Add initial database-operator config - ([`0d4dd0b`](https://github.com/eaasi/helm-charts/commit/0d4dd0bcccf8e8010ed9065b0171dfd3732dca40) by @O7EG)
+- Add initial database-cluster config - ([`369788b`](https://github.com/eaasi/helm-charts/commit/369788bf7026f57c2d3f00109bdcc9e9658ec599) by @O7EG)
+- Configure cluster's pod affinity - ([`4367aa9`](https://github.com/eaasi/helm-charts/commit/4367aa97ac264deeb2821ecfb949943c7f93e0f1) by @O7EG)
+- Add connection pooler for the primary instance - ([`cba5cb0`](https://github.com/eaasi/helm-charts/commit/cba5cb0a3b845f14e3de7a3581c96725a9162f0e) by @O7EG)
+
+### Testing
+
+- Add ping-test for configured connection poolers - ([`cad386f`](https://github.com/eaasi/helm-charts/commit/cad386fb82be42d34ef2f8bc37c77576a5f43b25) by @O7EG)
+
+### Continuous Integration
+
+- Add helper for deploying database-operators - ([`004748b`](https://github.com/eaasi/helm-charts/commit/004748bc1b11efed3b8f57c94debd48e1ac54d54) by @O7EG)
+- Add helper for deploying database-clusters - ([`9c57108`](https://github.com/eaasi/helm-charts/commit/9c5710818b52528891b926134cb91d9d61736b26) by @O7EG)
+
+### Documentation
+
+- Add initial README - ([`0276d03`](https://github.com/eaasi/helm-charts/commit/0276d037e81a5af708a45d5945b8e1d777929249) by @O7EG)
+- Describe a basic deployment procedure - ([`0927d89`](https://github.com/eaasi/helm-charts/commit/0927d89bc35afbd89f5f507311fd4bf4335e5668) by @O7EG)
+- Describe available configuration parameters - ([`0e02703`](https://github.com/eaasi/helm-charts/commit/0e02703f223ec294b1bb2a90b7d06e0a870ede4d) by @O7EG)
+- Describe how a development database can be deployed - ([`6cce9d2`](https://github.com/eaasi/helm-charts/commit/6cce9d2bc58a4344792b56e3d58fa1a5f622f463) by @O7EG)
+
+### Miscellaneous
+
+- Add initial `.helmignore` - ([`d7477d2`](https://github.com/eaasi/helm-charts/commit/d7477d260d46c770985df3e58d73728e6ad432ef) by @O7EG)
+- Add initial chart metadata - ([`68c760f`](https://github.com/eaasi/helm-charts/commit/68c760fdbffd8043eb73183fc2991436474f64dc) by @O7EG)
+- Add external chart repository `cnpg` - ([`e3a4591`](https://github.com/eaasi/helm-charts/commit/e3a45914489e1c394a2a2a2c1b332e49a768359a) by @O7EG)
+- Add dependency `@cnpg/cloudnative-pg` v0.23.2 - ([`17b1cf9`](https://github.com/eaasi/helm-charts/commit/17b1cf93bd33c5a619198d599642be4521845fa7) by @O7EG)
+- Add dependency `@cnpg/cluster` v0.2.1 - ([`7aa67a8`](https://github.com/eaasi/helm-charts/commit/7aa67a8f37cd0d306eaad3697792404600815c83) by @O7EG)
+- Fail early when operator and cluster are enabled - ([`2bbde88`](https://github.com/eaasi/helm-charts/commit/2bbde881502ba5c025528e5b338461e8ad442f43) by @O7EG)
+- Bump chart version to 0.5.0 - ([`5f692ed`](https://github.com/eaasi/helm-charts/commit/5f692ed519a36baf10981a03d635157202acbc41) by @O7EG)

--- a/charts/database/Chart.lock
+++ b/charts/database/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cloudnative-pg
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.23.2
+digest: sha256:80433e6b4e86900e9daa42348b8863d23370af8f9b4447b7299ba4d440c1bd61
+generated: "2025-03-20T16:50:24.991419617+01:00"

--- a/charts/database/Chart.lock
+++ b/charts/database/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: cloudnative-pg
   repository: https://cloudnative-pg.github.io/charts
   version: 0.23.2
-digest: sha256:80433e6b4e86900e9daa42348b8863d23370af8f9b4447b7299ba4d440c1bd61
-generated: "2025-03-20T16:50:24.991419617+01:00"
+- name: cluster
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.2.1
+digest: sha256:a08a4edc8fc4f25677834d9157b702c8eeb5c33ace93f60fd5f450f5ce393d76
+generated: "2025-03-20T17:10:37.269076118+01:00"

--- a/charts/database/Chart.yaml
+++ b/charts/database/Chart.yaml
@@ -17,3 +17,4 @@ dependencies:
   - repository: "@cnpg"
     name: cluster
     version: "0.2.1"
+    condition: cluster.enabled

--- a/charts/database/Chart.yaml
+++ b/charts/database/Chart.yaml
@@ -8,3 +8,8 @@ description: EAASI Database Helm Chart
 type: application
 sources:
   - https://github.com/eaasi/helm-charts
+dependencies:
+  - repository: "@cnpg"
+    name: cloudnative-pg
+    version: "0.23.2"
+    alias: operator

--- a/charts/database/Chart.yaml
+++ b/charts/database/Chart.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Yale University
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: database
+version: "0.1.0"
+description: EAASI Database Helm Chart
+type: application
+sources:
+  - https://github.com/eaasi/helm-charts

--- a/charts/database/Chart.yaml
+++ b/charts/database/Chart.yaml
@@ -14,3 +14,6 @@ dependencies:
     version: "0.23.2"
     alias: operator
     condition: operator.enabled
+  - repository: "@cnpg"
+    name: cluster
+    version: "0.2.1"

--- a/charts/database/Chart.yaml
+++ b/charts/database/Chart.yaml
@@ -13,3 +13,4 @@ dependencies:
     name: cloudnative-pg
     version: "0.23.2"
     alias: operator
+    condition: operator.enabled

--- a/charts/database/Chart.yaml
+++ b/charts/database/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: database
-version: "0.1.0"
+version: "0.5.0"
 description: EAASI Database Helm Chart
 type: application
 sources:

--- a/charts/database/README.md
+++ b/charts/database/README.md
@@ -32,3 +32,10 @@ A new *CNPG cluster* can be created with the following command:
 $ helm install database-cluster eaasi/database \
     --namespace database --create-namespace
 ```
+
+## Configuration
+
+A minimal configuration for an operator and a cluster is provided in the default [values.yaml](./values.yaml) file.
+For further details on all available parameters, please refer to the configuration files of the upstream [operator](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) and [cluster](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) charts.
+
+The extensive documentation for the CloudNativePG project can be found [here](https://cloudnative-pg.io/documentation/current/).

--- a/charts/database/README.md
+++ b/charts/database/README.md
@@ -1,3 +1,34 @@
 # EAASI Database Helm Chart
 
 This Helm chart deploys the EAASI Database on [Kubernetes](https://kubernetes.io/) using the [Helm](https://helm.sh) package manager.
+
+## Getting Started
+
+This chart depends on the [operator](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) and the [cluster](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) charts from the [CloudNativePG](https://github.com/cloudnative-pg) project.
+
+### Adding the Repositories
+
+```console
+$ helm repo add cnpg "https://cloudnative-pg.github.io/charts"
+$ helm repo add eaasi "https://eaasi.github.io/helm-charts"
+```
+
+### Installing the Operator
+
+First, the *CNPG operator* must be installed, since it provides several CRDs required for setting up new database *clusters*.
+Skip this step if the operator is already installed in your K8s cluster:
+
+```console
+$ helm install database-operator eaasi/database \
+    --namespace cnpg-system --create-namespace \
+    -f ./configs/operator.yaml
+```
+
+### Creating a Cluster
+
+A new *CNPG cluster* can be created with the following command:
+
+```console
+$ helm install database-cluster eaasi/database \
+    --namespace database --create-namespace
+```

--- a/charts/database/README.md
+++ b/charts/database/README.md
@@ -1,0 +1,3 @@
+# EAASI Database Helm Chart
+
+This Helm chart deploys the EAASI Database on [Kubernetes](https://kubernetes.io/) using the [Helm](https://helm.sh) package manager.

--- a/charts/database/configs/operator.yaml
+++ b/charts/database/configs/operator.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 Yale University
+# SPDX-License-Identifier: Apache-2.0
+
+# Override values for installing the operator
+
+operator:
+  # Enable the operator
+  enabled: true
+
+cluster:
+  # Disable the cluster
+  enabled: false

--- a/charts/database/templates/assertions.yaml
+++ b/charts/database/templates/assertions.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Yale University
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.operator.enabled .Values.cluster.enabled -}}
+{{- fail "Either the operator or the cluster should be enabled, not both!" -}}
+{{- end -}}

--- a/charts/database/templates/tests/pooler-ping.yaml
+++ b/charts/database/templates/tests/pooler-ping.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 Yale University
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.cluster.enabled -}}
+{{   $context := dict "Values" .Values.cluster "Release" .Release -}}
+{{   $fullname := include "cluster.fullname" $context -}}
+{{   $namespace := include "cluster.namespace" $context -}}
+{{   $secname := printf "%s-app" $fullname -}}
+{{   range $index, $pooler := .Values.cluster.poolers -}}
+{{     $svcname := printf "%s-pooler-%s" $fullname $pooler.name -}}
+{{     $jobname := printf "%s-ping-test" $svcname -}}
+{{/*
+Simple database ping test for a configured CNPG Pooler, adapted from:
+https://github.com/cloudnative-pg/charts/blob/cluster-v0.2.1/charts/cluster/templates/tests/ping.yaml
+*/ -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobname }}
+  namespace: {{ $namespace }}
+  labels:
+    app.kubernetes.io/component: database-ping-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ $jobname }}
+      namespace: {{ $namespace }}
+      labels:
+        app.kubernetes.io/component: database-ping-test
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: alpine
+          image: alpine:3.21
+          env:
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secname }}
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secname }}
+                  key: password
+            - name: PGDBNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secname }}
+                  key: dbname
+                  optional: true
+          command:
+            - "/bin/sh"
+          args:
+            - "-e"
+            - "-u"
+            - "-c"
+            - |
+              apk add postgresql-client
+              psql --no-password \
+                -h "{{ $svcname }}.{{ $namespace }}.svc.cluster.local" \
+                -p 5432 \
+                -d "${PGDBNAME:-$PGUSER}" \
+                -c "SELECT 1"
+{{   end -}}
+{{ end -}}

--- a/charts/database/values.yaml
+++ b/charts/database/values.yaml
@@ -37,6 +37,11 @@ cluster:
   cluster:
     # -- Number of instances
     instances: 1
+    # -- Affinity rules for Pods
+    affinity:
+      enablePodAntiAffinity: true
+      podAntiAffinityType: preferred
+      topologyKey: kubernetes.io/hostname
     # -- Database storage config
     storage:
       size: 1Gi

--- a/charts/database/values.yaml
+++ b/charts/database/values.yaml
@@ -16,3 +16,27 @@ operator:
   nameOverride: cloudnative-pg
   # -- Number of replicas
   replicaCount: 1
+
+# Configuration for the CNPG cluster:
+# https://github.com/cloudnative-pg/charts/tree/main/charts/cluster
+cluster:
+  # -- Should the cluster be enabled?
+  enabled: true
+  # -- Override cluster name
+  fullnameOverride: eaasi
+  # -- Override subchart name
+  nameOverride: database-cluster
+  # -- Cluster mode of operation
+  mode: standalone
+  # -- Type of the CNPG database
+  type: postgresql
+  # -- Version of the CNPG database
+  version:
+    postgresql: "17.4"
+  # -- CNPG cluster config
+  cluster:
+    # -- Number of instances
+    instances: 1
+    # -- Database storage config
+    storage:
+      size: 1Gi

--- a/charts/database/values.yaml
+++ b/charts/database/values.yaml
@@ -45,3 +45,14 @@ cluster:
     # -- Database storage config
     storage:
       size: 1Gi
+  # -- PgBouncer poolers
+  poolers:
+    - name: rw
+      type: rw
+      instances: 1
+      poolMode: transaction
+      parameters:
+        max_client_conn: "250"
+        default_pool_size: "20"
+        reserve_pool_size: "5"
+        min_pool_size: "5"

--- a/charts/database/values.yaml
+++ b/charts/database/values.yaml
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Yale University
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for the EAASI Database

--- a/charts/database/values.yaml
+++ b/charts/database/values.yaml
@@ -2,3 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default values for the EAASI Database
+
+# Configuration for the CNPG operator:
+# https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg
+operator:
+  # -- Should the operator be enabled?
+  enabled: false
+  # -- Override operator name
+  fullnameOverride: cnpg-operator
+  # -- Override subchart name
+  # NOTE: The original chart name must be used here for now, because
+  #       the upstream chart hard-codes it in multiple templates!
+  nameOverride: cloudnative-pg
+  # -- Number of replicas
+  replicaCount: 1

--- a/configs/committed.toml
+++ b/configs/committed.toml
@@ -24,3 +24,8 @@ allowed_types = [
   "style",
   "test",
 ]
+
+# allowed commit scopes
+allowed_scopes = [
+  "database",
+]

--- a/configs/typos.toml
+++ b/configs/typos.toml
@@ -6,6 +6,9 @@ extend-ignore-re = [
   "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
   # ignore blocks with "spellchecker:<on|off>"
   "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
+  # ignore false positives triggered by "ba" surrounded by numbers
+  "[0-9]+ba",
+  "ba[0-9]+",
 ]
 
 [default.extend-words]


### PR DESCRIPTION
This pull request introduces a new Helm chart for deploying the EAASI Database,
including configuration, documentation, and automation improvements:

- Add the `database` chart with support for deploying the CloudNativePG operator and a PostgreSQL cluster.
- Add new Just recipes for deploying and testing the database operator and cluster.
- Update the CI workflows to use custom Just recipes for building, deploying, and testing charts.
- Provide documentation for the new chart, including installation, configuration and usage instructions.

Closes: #9
Closes: #10
